### PR TITLE
fix: import event source only default export

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,6 @@ jobs:
     name: Node.js
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
-      version: '18.19.0, 18, 20, 22'
+      version: '18.19.0, 18, 20, 22, 23'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @eggjs/watcher
 
 [![NPM version][npm-image]][npm-url]
-[![Node.js CI](https://github.com/eggjs/egg-watcher/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/egg-watcher/actions/workflows/nodejs.yml)
+[![Node.js CI](https://github.com/eggjs/watcher/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/watcher/actions/workflows/nodejs.yml)
 [![Test coverage][codecov-image]][codecov-url]
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![npm download][download-image]][download-url]
@@ -9,8 +9,8 @@
 
 [npm-image]: https://img.shields.io/npm/v/@eggjs/watcher.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/@eggjs/watcher
-[codecov-image]: https://codecov.io/github/eggjs/egg-watcher/coverage.svg?branch=master
-[codecov-url]: https://codecov.io/github/eggjs/egg-watcher?branch=master
+[codecov-image]: https://codecov.io/github/eggjs/watcher/coverage.svg?branch=master
+[codecov-url]: https://codecov.io/github/eggjs/watcher?branch=master
 [snyk-image]: https://snyk.io/test/npm/@eggjs/watcher/badge.svg?style=flat-square
 [snyk-url]: https://snyk.io/test/npm/@eggjs/watcher
 [download-image]: https://img.shields.io/npm/dm/@eggjs/watcher.svg?style=flat-square
@@ -56,7 +56,7 @@ Stop watching file(s).
 
 ### `development` Mode
 
-There's a built-in [development mode](https://github.com/eggjs/egg-watcher/blob/master/src/lib/event-sources/development.ts) which works in local(env is `local`). Once files on disk is modified it will emit a `change` event immediately.
+There's a built-in [development mode](https://github.com/eggjs/watcher/blob/master/src/lib/event-sources/development.ts) which works in local(env is `local`). Once files on disk is modified it will emit a `change` event immediately.
 
 ### Customize Watching Mode
 
@@ -142,6 +142,6 @@ Please open an issue [here](https://github.com/eggjs/egg/issues).
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=eggjs/egg-watcher)](https://github.com/eggjs/egg-watcher/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=eggjs/watcher)](https://github.com/eggjs/watcher/graphs/contributors)
 
 Made with [contributors-img](https://contrib.rocks).

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "ci": "egg-bin cov",
     "prepublishOnly": "tshy && tshy-after"
   },
-  "homepage": "https://github.com/eggjs/egg-watcher",
+  "homepage": "https://github.com/eggjs/watcher",
   "repository": {
     "type": "git",
-    "url": "git@github.com:eggjs/egg-watcher.git"
+    "url": "git@github.com:eggjs/watcher.git"
   },
   "keywords": [
     "egg-watcher",

--- a/src/lib/watcher.ts
+++ b/src/lib/watcher.ts
@@ -25,7 +25,9 @@ export class Watcher extends Base {
     const watcherType = this.#config.watcher.type;
     let EventSource: typeof BaseEventSource = this.#config.watcher.eventSources[watcherType] as any;
     if (typeof EventSource === 'string') {
-      EventSource = await importModule(EventSource);
+      EventSource = await importModule(EventSource, {
+        importDefaultOnly: true,
+      });
     }
 
     // chokidar => watcherChokidar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Node.js version 23 in the CI workflow.
  
- **Documentation**
	- Updated URLs for CI and coverage badges in the README file to reflect the new repository path.
  
- **Chores**
	- Modified homepage and repository URLs in the `package.json` file for rebranding purposes.
  
- **Bug Fixes**
	- Refined the import process for the EventSource in the watcher functionality.
	- Temporarily disabled the unwatching functionality by commenting out the method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->