### PR TITLE
fix: should export watcher from EggWatcherApplicationCore

### DIFF
--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -1,16 +1,17 @@
-import type { Application, Agent, ILifecycleBoot } from 'egg';
+import type { ILifecycleBoot } from 'egg';
+import { EggWatcherApplicationCore } from './types.js';
 import { Watcher } from './watcher.js';
 
 export class Boot implements ILifecycleBoot {
-  #app: Application | Agent;
+  #app: EggWatcherApplicationCore;
   #watcher: Watcher;
 
-  constructor(appOrAgent: Application | Agent) {
+  constructor(appOrAgent: EggWatcherApplicationCore) {
     this.#app = appOrAgent;
     this.#watcher = this.#app.watcher = this.#app.cluster(Watcher, {})
       .delegate('watch', 'subscribe')
-      .create(appOrAgent.config)
-      .on('info', (msg: string, ...args: any[]) => this.#app.coreLogger.info(msg, ...args))
+      .create(appOrAgent.config);
+    this.#watcher.on('info', (msg: string, ...args: any[]) => this.#app.coreLogger.info(msg, ...args))
       .on('warn', (msg: string, ...args: any[]) => this.#app.coreLogger.warn(msg, ...args))
       .on('error', (msg: string, ...args: any[]) => this.#app.coreLogger.error(msg, ...args));
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { WatchEventType, Stats } from 'node:fs';
+import type { EggApplicationCore, EggAppConfig } from 'egg';
 import type { Watcher } from './watcher.js';
 
 export interface WatcherConfig {
@@ -18,18 +19,8 @@ export interface ChangeInfo {
   path: string;
 }
 
-declare module 'egg' {
-  export interface EggWatcherAgent {
-    watcher: Watcher;
-  }
-  export interface Agent extends EggWatcherAgent {}
-
-  export interface EggWatcherApplication {
-    watcher: Watcher;
-  }
-  export interface Application extends EggWatcherApplication {}
-
-  export interface EggWatcherAppConfig extends WatcherConfig {}
-
-  export interface EggAppConfig extends EggWatcherAppConfig {}
+export interface EggWatcherApplicationCore extends EggApplicationCore {
+  watcher: Watcher;
 }
+
+export type EggWatcherAppConfig = EggAppConfig & WatcherConfig;

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { strict as assert } from 'node:assert';
 import { mm, MockApplication } from 'egg-mock';
 import { getFilePath } from './utils.js';
+import { ChangeInfo } from '../src/index.js';
 
 describe('test/watcher.test.ts', () => {
   let app: MockApplication;
@@ -13,7 +14,8 @@ describe('test/watcher.test.ts', () => {
       baseDir: 'apps/watcher-type-default',
     });
     await app.ready();
-    const content = fs.readFileSync(getFilePath('apps/watcher-type-default/logs/watcher-type-default/egg-agent.log'), 'utf8');
+    const content = fs.readFileSync(
+      getFilePath('apps/watcher-type-default/logs/watcher-type-default/egg-agent.log'), 'utf8');
     assert.match(content, /defaultEventSource watcher will NOT take effect/);
   });
 
@@ -25,12 +27,13 @@ describe('test/watcher.test.ts', () => {
     await app.ready();
 
     const p1 = new Promise<void>(resolve => {
-      app.watcher.watch('xxxx', (info: any) => {
+      app.watcher.watch('xxxx', (info: ChangeInfo & { foo: string }) => {
         assert.equal(info.path, 'xxxx');
         // ensure use config.custom
         assert.equal(info.foo, 'bar');
 
-        const content = fs.readFileSync(getFilePath('apps/watcher-custom-event-source/logs/watcher-custom-event-source/egg-agent.log'), 'utf8');
+        const content = fs.readFileSync(
+          getFilePath('apps/watcher-custom-event-source/logs/watcher-custom-event-source/egg-agent.log'), 'utf8');
         assert.match(content, /warn12345/);
         assert.match(content, /info12345/);
         resolve();
@@ -38,7 +41,7 @@ describe('test/watcher.test.ts', () => {
     });
 
     const p2 = new Promise<void>(resolve => {
-      app.watcher.watch('xxxx', info => {
+      app.watcher.watch('xxxx', (info: ChangeInfo) => {
         // watch again success
         assert.equal(info.path, 'xxxx');
         resolve();
@@ -55,13 +58,14 @@ describe('test/watcher.test.ts', () => {
     await app.ready();
 
     await new Promise<void>(resolve => {
-      app.watcher.watch([ '/home/admin/xxx' ], (info: any) => {
+      app.watcher.watch([ '/home/admin/xxx' ], (info: ChangeInfo & { foo: string }) => {
         assert.equal(info.path, '/home/admin');
 
         // ensure use config.custom
         assert.equal(info.foo, 'bar');
 
-        const content = fs.readFileSync(getFilePath('apps/watcher-custom-event-source-fuzzy/logs/watcher-custom-event-source-fuzzy/egg-agent.log'), 'utf8');
+        const content = fs.readFileSync(
+          getFilePath('apps/watcher-custom-event-source-fuzzy/logs/watcher-custom-event-source-fuzzy/egg-agent.log'), 'utf8');
         assert(content.includes('warn12345'));
         assert(content.includes('info12345'));
         resolve();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface `EggWatcherApplicationCore` for improved application structure.
	- Added a consolidated type `EggWatcherAppConfig` for simplified configuration management.

- **Bug Fixes**
	- Enhanced type definitions for watcher callbacks, improving type safety in tests.

- **Refactor**
	- Streamlined type handling in the `Boot` class for clarity and specificity.
	- Removed outdated interfaces to simplify the type hierarchy in the Egg framework. 

- **Tests**
	- Improved readability of test cases by adjusting formatting and enhancing type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->