### PR TITLE
fix: export watcher type on eggjs/core namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,19 @@
     "name": "watcher",
     "exports": {
       "import": "./dist/esm",
-      "require": "./dist/commonjs"
+      "require": "./dist/commonjs",
+      "typescript": "./src"
     }
   },
   "scripts": {
     "lint": "eslint --cache src test --ext .ts",
-    "pretest": "npm run lint -- --fix && npm run prepublishOnly",
+    "pretest": "npm run clean && npm run lint -- --fix",
     "test": "egg-bin test",
-    "preci": "npm run lint && npm run prepublishOnly && attw --pack",
+    "preci": "npm run clean && npm run lint",
     "ci": "egg-bin cov",
-    "prepublishOnly": "tshy && tshy-after"
+    "postci": "npm run prepublishOnly && attw --pack && npm run clean",
+    "prepublishOnly": "tshy && tshy-after",
+    "clean": "rimraf dist"
   },
   "homepage": "https://github.com/eggjs/watcher",
   "repository": {
@@ -35,7 +38,8 @@
     "node": ">= 18.19.0"
   },
   "dependencies": {
-    "@eggjs/utils": "^4.0.3",
+    "@eggjs/core": "^6.2.13",
+    "@eggjs/utils": "^4.2.3",
     "camelcase": "^5.0.0",
     "sdk-base": "^5.0.0"
   },
@@ -45,8 +49,9 @@
     "@types/node": "22",
     "@types/mocha": "10",
     "egg": "beta",
-    "egg-bin": "beta",
-    "egg-mock": "beta",
+    "@eggjs/bin": "7",
+    "@eggjs/mock": "6",
+    "rimraf": "6",
     "eslint": "8",
     "eslint-config-egg": "14",
     "tshy": "3",

--- a/src/config/config.default.ts
+++ b/src/config/config.default.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { getSourceDirname } from '../lib/utils.js';
+import type { WatcherConfig } from '../lib/types.js';
 
 export default {
   /**
@@ -13,5 +14,5 @@ export default {
       default: path.join(getSourceDirname(), 'lib', 'event-sources', 'default'),
       development: path.join(getSourceDirname(), 'lib', 'event-sources', 'development'),
     },
-  },
+  } as WatcherConfig,
 };

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -1,5 +1,7 @@
+import type { WatcherConfig } from '../lib/types.js';
+
 export default {
   watcher: {
     type: 'development',
-  },
+  } as WatcherConfig,
 };

--- a/src/config/config.unittest.ts
+++ b/src/config/config.unittest.ts
@@ -1,5 +1,7 @@
+import type { WatcherConfig } from '../lib/types.js';
+
 export default {
   watcher: {
     type: 'development',
-  },
+  } as WatcherConfig,
 };

--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -1,12 +1,11 @@
-import type { ILifecycleBoot } from 'egg';
-import { EggWatcherApplicationCore } from './types.js';
+import type { ILifecycleBoot, EggApplicationCore } from 'egg';
 import { Watcher } from './watcher.js';
 
 export class Boot implements ILifecycleBoot {
-  #app: EggWatcherApplicationCore;
+  #app: EggApplicationCore;
   #watcher: Watcher;
 
-  constructor(appOrAgent: EggWatcherApplicationCore) {
+  constructor(appOrAgent: EggApplicationCore) {
     this.#app = appOrAgent;
     this.#watcher = this.#app.watcher = this.#app.cluster(Watcher, {})
       .delegate('watch', 'subscribe')

--- a/src/lib/event-sources/index.ts
+++ b/src/lib/event-sources/index.ts
@@ -1,3 +1,9 @@
-export * from './base.js';
-export * from './default.js';
-export * from './development.js';
+import { BaseEventSource } from './base.js';
+import DefaultEventSource from './default.js';
+import DevelopmentEventSource from './development.js';
+
+export {
+  BaseEventSource,
+  DefaultEventSource,
+  DevelopmentEventSource,
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,16 +1,20 @@
 import type { WatchEventType, Stats } from 'node:fs';
-import type { EggApplicationCore, EggAppConfig } from 'egg';
 import type { Watcher } from './watcher.js';
 
 export interface WatcherConfig {
-  watcher: {
-    type: string;
-    eventSources: Record<string, string>;
-  };
-  [key: string]: Record<string, any>;
+  /**
+   * event source type, default is `default`
+   * can be `default` or `development`
+   */
+  type: string;
+  /**
+   * event sources
+   * key is event source type, value is event source module path
+   */
+  eventSources: Record<string, string>;
 }
 
-export interface ChangeInfo {
+export interface ChangeInfo extends Record<string, any> {
   event: WatchEventType;
   /**
    * file stat if path exists
@@ -19,8 +23,12 @@ export interface ChangeInfo {
   path: string;
 }
 
-export interface EggWatcherApplicationCore extends EggApplicationCore {
-  watcher: Watcher;
-}
+declare module '@eggjs/core' {
+  interface EggCore {
+    watcher: Watcher;
+  }
 
-export type EggWatcherAppConfig = EggAppConfig & WatcherConfig;
+  interface EggAppConfig {
+    watcher: WatcherConfig;
+  }
+}

--- a/src/lib/watcher.ts
+++ b/src/lib/watcher.ts
@@ -2,19 +2,20 @@ import { debuglog } from 'node:util';
 import { Base } from 'sdk-base';
 import camelcase from 'camelcase';
 import { importModule } from '@eggjs/utils';
+import type { EggAppConfig } from '@eggjs/core';
 import { BaseEventSource } from './event-sources/base.js';
 import { isEqualOrParentPath } from './utils.js';
-import type { ChangeInfo, WatcherConfig } from './types.js';
+import type { ChangeInfo } from './types.js';
 
 const debug = debuglog('@eggjs/watcher/lib/watcher');
 
 export type WatchListener = (info: ChangeInfo) => void;
 
 export class Watcher extends Base {
-  #config: WatcherConfig;
+  #config: EggAppConfig;
   #eventSource: BaseEventSource;
 
-  constructor(config: WatcherConfig) {
+  constructor(config: EggAppConfig) {
     super({
       initMethod: '_init',
     });
@@ -23,7 +24,7 @@ export class Watcher extends Base {
 
   protected async _init() {
     const watcherType = this.#config.watcher.type;
-    let EventSource: typeof BaseEventSource = this.#config.watcher.eventSources[watcherType] as any;
+    let EventSource = this.#config.watcher.eventSources[watcherType] as unknown as typeof BaseEventSource;
     if (typeof EventSource === 'string') {
       EventSource = await importModule(EventSource, {
         importDefaultOnly: true,

--- a/test/development.test.ts
+++ b/test/development.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { strict as assert } from 'node:assert';
 import { scheduler } from 'node:timers/promises';
-import { mm, MockApplication } from 'egg-mock';
+import { mm, MockApplication } from '@eggjs/mock';
 import { getFilePath } from './utils.js';
 
 const file_path1 = getFilePath('apps/watcher-development-app/tmp.txt');

--- a/test/development_cluster.test.ts
+++ b/test/development_cluster.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { strict as assert } from 'node:assert';
 import { scheduler } from 'node:timers/promises';
-import { mm, MockApplication } from 'egg-mock';
+import { mm, MockApplication } from '@eggjs/mock';
 import { getFilePath } from './utils.js';
 
 const file_path1 = getFilePath('apps/watcher-development-app/tmp.txt');

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,13 @@
+import { strict as assert } from 'node:assert';
+import * as watcher from '../src/index.js';
+
+describe('test/index.test.ts', () => {
+  it('should exports work', async () => {
+    assert.deepEqual(Object.keys(watcher), [
+      'BaseEventSource',
+      'DefaultEventSource',
+      'DevelopmentEventSource',
+      'Watcher',
+    ]);
+  });
+});

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { strict as assert } from 'node:assert';
-import { mm, MockApplication } from 'egg-mock';
+import { mm, MockApplication } from '@eggjs/mock';
 import { getFilePath } from './utils.js';
 import { ChangeInfo } from '../src/index.js';
 
@@ -27,7 +27,7 @@ describe('test/watcher.test.ts', () => {
     await app.ready();
 
     const p1 = new Promise<void>(resolve => {
-      app.watcher.watch('xxxx', (info: ChangeInfo & { foo: string }) => {
+      app.watcher.watch('xxxx', (info: ChangeInfo) => {
         assert.equal(info.path, 'xxxx');
         // ensure use config.custom
         assert.equal(info.foo, 'bar');
@@ -58,7 +58,7 @@ describe('test/watcher.test.ts', () => {
     await app.ready();
 
     await new Promise<void>(resolve => {
-      app.watcher.watch([ '/home/admin/xxx' ], (info: ChangeInfo & { foo: string }) => {
+      app.watcher.watch([ '/home/admin/xxx' ], (info: ChangeInfo) => {
         assert.equal(info.path, '/home/admin');
 
         // ensure use config.custom


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Dependencies**
  - Updated package dependencies, including upgrading `@eggjs/utils`, `@eggjs/core`, and replacing `egg-bin` and `egg-mock` with `@eggjs/bin` and `@eggjs/mock`

- **Configuration**
  - Enhanced TypeScript support with new type definitions for watcher configuration
  - Improved type safety for configuration objects across different environments

- **Testing**
  - Updated test imports and type definitions
  - Added new export verification test

- **Chores**
  - Modified build and linting scripts
  - Added clean script for build artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->